### PR TITLE
[FIX] desabilitação de opção de auto-intall de módulo *disable footer*

### DIFF
--- a/disable_powered_odoo_footer/__openerp__.py
+++ b/disable_powered_odoo_footer/__openerp__.py
@@ -20,5 +20,4 @@
         'views/view_disable_powered_odoo_footer.xml',
     ],
     'installable': True,
-    'auto_install': True,
 }


### PR DESCRIPTION
desabilitando auto-install do módulo, pois removia o footer do tema.