### PR TITLE
[FIX] l10n br geo localization travisci

### DIFF
--- a/admin_development_features/__init__.py
+++ b/admin_development_features/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 #    Admin Development Features to Odoo
 #    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-#    @author Michell Stuttgart <m.faria@itimpacta.org.br>
+#    @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html

--- a/admin_development_features/__manifest__.py
+++ b/admin_development_features/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #    Admin Development Features to Odoo
 #    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-#    @author Michell Stuttgart <m.faria@itimpacta.org.br>
+#    @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {

--- a/disable_powered_odoo_footer/__manifest__.py
+++ b/disable_powered_odoo_footer/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #    Disable Powered By Odoo Footer to Odoo
 #    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-#    @author Michell Stuttgart <m.faria@itimpacta.org.br>
+#    @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {

--- a/key_wallet/__init__.py
+++ b/key_wallet/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Key Wallet to Odoo
 # Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-# @author Michell Stuttgart <m.faria@itimpacta.org.br>
+# @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import models

--- a/key_wallet/__manifest__.py
+++ b/key_wallet/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #    Key Wallet to Odoo
 #    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-#    @author Michell Stuttgart <m.faria@itimpacta.org.br>
+#    @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {

--- a/key_wallet/models/__init__.py
+++ b/key_wallet/models/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Key Wallet to Odoo
 # Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-# @author Michell Stuttgart <m.faria@itimpacta.org.br>
+# @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import key_wallet_category

--- a/key_wallet/models/key_wallet_category.py
+++ b/key_wallet/models/key_wallet_category.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-# @author Michell Stuttgart <m.faria@itimpacta.org.br>
+# @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import models, fields

--- a/key_wallet/models/key_wallet_password.py
+++ b/key_wallet/models/key_wallet_password.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-# @author Michell Stuttgart <m.faria@itimpacta.org.br>
+# @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import api, fields, models

--- a/l10n_br_geo_localization/__init__.py
+++ b/l10n_br_geo_localization/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #    Geo localization to Brazil Localization to Odoo
 #    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-#    @author Michell Stuttgart <m.faria@itimpacta.org.br>
+#    @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.htmltml
 
 from . import models

--- a/l10n_br_geo_localization/__manifest__.py
+++ b/l10n_br_geo_localization/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #    Geo localization to Brazil Localization to Odoo
 #    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-#    @author Michell Stuttgart <m.faria@itimpacta.org.br>
+#    @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {

--- a/l10n_br_geo_localization/__manifest__.py
+++ b/l10n_br_geo_localization/__manifest__.py
@@ -19,5 +19,5 @@
     'data': [
         'views/res_partner_view.xml',
     ],
-    'installable': True,
+    'installable': False,
 }

--- a/l10n_br_geo_localization/models/__init__.py
+++ b/l10n_br_geo_localization/models/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-#    Geo localization to Brazil Localization to Odoo
-#    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-#    @author Michell Stuttgart <m.faria@itimpacta.org.br>
+# Geo localization to Brazil Localization to Odoo
+# Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
+# @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import res_partner

--- a/l10n_br_geo_localization/models/res_partner.py
+++ b/l10n_br_geo_localization/models/res_partner.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-#    Geo localization to Brazil Localization to Odoo
-#    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-#    @author Michell Stuttgart <m.faria@itimpacta.org.br>
+# Geo localization to Brazil Localization to Odoo
+# Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
+# @author Michell Stuttgart <michellstut@gmail.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from openerp import models, api
+from odoo import models, api
 
 
 class ResPartner(models.Model):

--- a/l10n_br_geo_localization/tests/__init__.py
+++ b/l10n_br_geo_localization/tests/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-#    Geo localization to Brazil Localization to Odoo
-#    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
-#    @author Aldo Soares <a.soares@itimpacta.org.br>
+# Geo localization to Brazil Localization to Odoo
+# Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
+# @author Aldo Soares <a.soares@itimpacta.org.br>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import test_geo_localization

--- a/l10n_br_geo_localization/tests/test_geo_localization.py
+++ b/l10n_br_geo_localization/tests/test_geo_localization.py
@@ -1,9 +1,16 @@
+# -*- coding: utf-8 -*-
+# Geo localization to Brazil Localization to Odoo
+# Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
+# @author Aldo Soares <a.soares@itimpacta.org.br>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
 import mock
 
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 
 
 class TestResPartner(TransactionCase):
+
     @mock.patch('openerp.addons.base_geolocalize.models.res_partner.json.load')
     def test_zip_search(self, mock_api_call):
         mock_api_call.return_value = {


### PR DESCRIPTION
Conserta rrro de travisci do modulo *l10n_br_geo_localization*

O módulo foi deixado como não instalável pois o mesmo não tem utilidade no momento, uma vez que o tema que o utiliza não foi migrado para a api 10.0

O PR tambem traz ajuste no copyright do módulo

FIX #53 