### PR TITLE
[REF]Trazer flegado por default campo 'estágio padrão' e 'padrão

### DIFF
--- a/project_default_stages/models/project_project.py
+++ b/project_default_stages/models/project_project.py
@@ -7,7 +7,7 @@ class ProjectProject(models.Model):
     _inherit = 'project.project'
 
     bring_default_task_type = fields.Boolean(string='Get default stages',
-                                             deafult=True,
+                                             default=True,
                                              help='Add to this project, '
                                                   'all stage defined like '
                                                   'default')

--- a/project_default_stages/models/project_task_type.py
+++ b/project_default_stages/models/project_task_type.py
@@ -8,6 +8,7 @@ class ProjectTaskType(models.Model):
     _inherit = 'project.task.type'
 
     is_default = fields.Boolean(string='Default',
+                                default=True,
                                 help='Allows assignment of the current stage '
                                      'to new projects that will be created.')
 


### PR DESCRIPTION
Trazer marcado por *default* campo 'estágio padrão' na criação do projeto e campo 'padrão' na criação do  estágio.

close https://github.com/multidadosti-erp/erp-project/issues/44