### PR TITLE
Menu de Marcadores do projeto desapareceu

### DIFF
--- a/project_default_stages/views/project_project.xml
+++ b/project_default_stages/views/project_project.xml
@@ -13,5 +13,6 @@
 
         </field>
     </record>
-
+    <menuitem action="project.project_tags_action" id="project.menu_project_tags_act"
+              parent="project.menu_project_config" groups="project.group_project_manager"/>
 </odoo>


### PR DESCRIPTION
Sobscrevi a action 'project_tags_action' do menu de marcadores, pois estava jabilitado para visualização apenas para recursos técnicos e no momento nao faz sentido. Alterei para o gerente de projeto tambem conseguir editar"

close https://github.com/multidadosti-erp/erp-project/issues/166
