### PR TITLE
T1829 - Ajustar/Implementar mecanismo atual de pagamentos para geração de extrato valido

### DIFF
--- a/general_payments/tests/test_account_payment.py
+++ b/general_payments/tests/test_account_payment.py
@@ -303,7 +303,7 @@ class TestAccountPayment(TransactionCase):
         # 'account.move' record ?
         self.assertEqual(self.supplier_payment.move_id.paid_status, 'paid')
 
-    def test_reverse(self):
+    def test_cancel(self):
         ctx = {
             'financial_move': True,
         }
@@ -311,10 +311,8 @@ class TestAccountPayment(TransactionCase):
         # Two move records must be created
         self.assertEqual(len(self.env['account.move'].search([])), 2)
 
-        self.supplier_payment.reverse()
+        self.supplier_payment.cancel()
         self.assertEqual(len(self.env['account.move'].search([]).ids), False)
-
-        self.assertEqual(self.supplier_payment.state, 'draft')
 
     def test__onchange_payment_type(self):
         res = self.payment_transfer._onchange_payment_type()

--- a/general_payments/views/account_payment.xml
+++ b/general_payments/views/account_payment.xml
@@ -11,35 +11,13 @@
             </xpath>
 
         </field>
-    </record>
+    </record>  
 
     <record id="view_br_account_payment_payment_form_inherit" model="ir.ui.view">
         <field name="name">account.detached.payment.form.inherit</field>
         <field name="model">account.payment</field>
         <field name="inherit_id" ref="br_account_payment.view_br_account_payment_payment_cancel_form_inherit"/>
         <field name="arch" type="xml">
-
-            <button name="cancel" position="attributes">
-                <attribute name="attrs">
-                    {'invisible': ['|',
-                        ('state', 'in', ['draft','cancelled']),
-                        ('invoice_ids', '=', [])]}
-                </attribute>
-            </button>
-
-            <button name="cancel" position="after">
-                <field name="invoice_ids" invisible="1"/>
-                <button name="reverse"
-                        string="Reverse"
-                        confirm="This action will revert this payment, which will deletes
-                            all move records created, are you sure this?"
-                        type="object"
-                        class="oe_highlight"
-                        attrs="{'invisible': ['|',
-                            ('state', 'in', ['draft','cancelled']),
-                            ('invoice_ids', '!=', [])]}"/>
-            </button>
-
 
             <xpath expr="//field[@name='journal_id']" position="after">
                 <field name="general_account_id" attrs="{'required': [('payment_type', 'in', ('inbound', 'outbound')),('state', '=', 'draft')], 'invisible': ['|',('payment_type', 'not in', ('inbound', 'outbound')),'&amp;',('state', '!=', 'draft'),('general_account_id', '=', False)], 'readonly': [('state', '!=', 'draft')]}"/>


### PR DESCRIPTION
# Descrição

**Altera método de lançar pagamentos**
- Remove atribuição de contexto em implementações ancestrais de
método de postagem.
- Organiza o código do método

**Mescla método 'reverse' a 'cancel' em model de pagamentos**
- Reorganização do antigo método de reversão de movimentações financeira
em método de cancelamento.
- Remoção de regras para exibição do botão de cancelamento em interface
de pagamentos e exclusão do botão de reversão de movimentações.